### PR TITLE
Update .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
   },
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "browser", true
   },
   "extends": "eslint:recommended",
   "rules": {


### PR DESCRIPTION
Tried the "shared-node-browser" env setting but that didn't seem to work so :shrug:
Anyway this should stop vscode from yelling at you that things like "window" and "document" are undefined.